### PR TITLE
add isKilled field to gauges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,8 @@ node_modules/
 build/
 
 # Subgraph stuff
-subgraph.yaml
 src/types/
+subgraph*.yaml
 
 # Jetbrains
 .idea/

--- a/abis/LiquidityGaugeV5.json
+++ b/abis/LiquidityGaugeV5.json
@@ -1,1039 +1,1006 @@
 [
     {
-        "name": "Deposit",
-        "inputs": [
+      "name": "Deposit",
+      "inputs": [
+        {
+          "name": "provider",
+          "type": "address",
+          "indexed": true
+        },
+        {
+          "name": "value",
+          "type": "uint256",
+          "indexed": false
+        }
+      ],
+      "anonymous": false,
+      "type": "event"
+    },
+    {
+      "name": "Withdraw",
+      "inputs": [
+        {
+          "name": "provider",
+          "type": "address",
+          "indexed": true
+        },
+        {
+          "name": "value",
+          "type": "uint256",
+          "indexed": false
+        }
+      ],
+      "anonymous": false,
+      "type": "event"
+    },
+    {
+      "name": "UpdateLiquidityLimit",
+      "inputs": [
+        {
+          "name": "user",
+          "type": "address",
+          "indexed": true
+        },
+        {
+          "name": "original_balance",
+          "type": "uint256",
+          "indexed": false
+        },
+        {
+          "name": "original_supply",
+          "type": "uint256",
+          "indexed": false
+        },
+        {
+          "name": "working_balance",
+          "type": "uint256",
+          "indexed": false
+        },
+        {
+          "name": "working_supply",
+          "type": "uint256",
+          "indexed": false
+        }
+      ],
+      "anonymous": false,
+      "type": "event"
+    },
+    {
+      "name": "Transfer",
+      "inputs": [
+        {
+          "name": "_from",
+          "type": "address",
+          "indexed": true
+        },
+        {
+          "name": "_to",
+          "type": "address",
+          "indexed": true
+        },
+        {
+          "name": "_value",
+          "type": "uint256",
+          "indexed": false
+        }
+      ],
+      "anonymous": false,
+      "type": "event"
+    },
+    {
+      "name": "Approval",
+      "inputs": [
+        {
+          "name": "_owner",
+          "type": "address",
+          "indexed": true
+        },
+        {
+          "name": "_spender",
+          "type": "address",
+          "indexed": true
+        },
+        {
+          "name": "_value",
+          "type": "uint256",
+          "indexed": false
+        }
+      ],
+      "anonymous": false,
+      "type": "event"
+    },
+    {
+      "name": "RewardDistributorUpdated",
+      "inputs": [
+        {
+          "name": "reward_token",
+          "type": "address",
+          "indexed": true
+        },
+        {
+          "name": "distributor",
+          "type": "address",
+          "indexed": false
+        }
+      ],
+      "anonymous": false,
+      "type": "event"
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "minter",
+          "type": "address"
+        },
+        {
+          "name": "veBoostProxy",
+          "type": "address"
+        },
+        {
+          "name": "authorizerAdaptor",
+          "type": "address"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "deposit",
+      "inputs": [
+        {
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "deposit",
+      "inputs": [
+        {
+          "name": "_value",
+          "type": "uint256"
+        },
+        {
+          "name": "_addr",
+          "type": "address"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "deposit",
+      "inputs": [
+        {
+          "name": "_value",
+          "type": "uint256"
+        },
+        {
+          "name": "_addr",
+          "type": "address"
+        },
+        {
+          "name": "_claim_rewards",
+          "type": "bool"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "withdraw",
+      "inputs": [
+        {
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "withdraw",
+      "inputs": [
+        {
+          "name": "_value",
+          "type": "uint256"
+        },
+        {
+          "name": "_claim_rewards",
+          "type": "bool"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "claim_rewards",
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "claim_rewards",
+      "inputs": [
+        {
+          "name": "_addr",
+          "type": "address"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "claim_rewards",
+      "inputs": [
+        {
+          "name": "_addr",
+          "type": "address"
+        },
+        {
+          "name": "_receiver",
+          "type": "address"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "transferFrom",
+      "inputs": [
+        {
+          "name": "_from",
+          "type": "address"
+        },
+        {
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "transfer",
+      "inputs": [
+        {
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "approve",
+      "inputs": [
+        {
+          "name": "_spender",
+          "type": "address"
+        },
+        {
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "permit",
+      "inputs": [
+        {
+          "name": "_owner",
+          "type": "address"
+        },
+        {
+          "name": "_spender",
+          "type": "address"
+        },
+        {
+          "name": "_value",
+          "type": "uint256"
+        },
+        {
+          "name": "_deadline",
+          "type": "uint256"
+        },
+        {
+          "name": "_v",
+          "type": "uint8"
+        },
+        {
+          "name": "_r",
+          "type": "bytes32"
+        },
+        {
+          "name": "_s",
+          "type": "bytes32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "increaseAllowance",
+      "inputs": [
+        {
+          "name": "_spender",
+          "type": "address"
+        },
+        {
+          "name": "_added_value",
+          "type": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "decreaseAllowance",
+      "inputs": [
+        {
+          "name": "_spender",
+          "type": "address"
+        },
+        {
+          "name": "_subtracted_value",
+          "type": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "user_checkpoint",
+      "inputs": [
+        {
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "set_rewards_receiver",
+      "inputs": [
+        {
+          "name": "_receiver",
+          "type": "address"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "kick",
+      "inputs": [
+        {
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "deposit_reward_token",
+      "inputs": [
+        {
+          "name": "_reward_token",
+          "type": "address"
+        },
+        {
+          "name": "_amount",
+          "type": "uint256"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "add_reward",
+      "inputs": [
+        {
+          "name": "_reward_token",
+          "type": "address"
+        },
+        {
+          "name": "_distributor",
+          "type": "address"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "set_reward_distributor",
+      "inputs": [
+        {
+          "name": "_reward_token",
+          "type": "address"
+        },
+        {
+          "name": "_distributor",
+          "type": "address"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "killGauge",
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "unkillGauge",
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "claimed_reward",
+      "inputs": [
+        {
+          "name": "_addr",
+          "type": "address"
+        },
+        {
+          "name": "_token",
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "claimable_reward",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address"
+        },
+        {
+          "name": "_reward_token",
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "claimable_tokens",
+      "inputs": [
+        {
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "integrate_checkpoint",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "future_epoch_time",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "inflation_rate",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "decimals",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "version",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "allowance",
+      "inputs": [
+        {
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "initialize",
+      "inputs": [
+        {
+          "name": "_lp_token",
+          "type": "address"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "balanceOf",
+      "inputs": [
+        {
+          "name": "arg0",
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "totalSupply",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "name",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "symbol",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "DOMAIN_SEPARATOR",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "nonces",
+      "inputs": [
+        {
+          "name": "arg0",
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "lp_token",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "is_killed",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "reward_count",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "reward_data",
+      "inputs": [
+        {
+          "name": "arg0",
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "components": [
             {
-                "name": "provider",
-                "type": "address",
-                "indexed": true
+              "name": "token",
+              "type": "address"
             },
             {
-                "name": "value",
-                "type": "uint256",
-                "indexed": false
-            }
-        ],
-        "anonymous": false,
-        "type": "event"
-    },
-    {
-        "name": "Withdraw",
-        "inputs": [
-            {
-                "name": "provider",
-                "type": "address",
-                "indexed": true
+              "name": "distributor",
+              "type": "address"
             },
             {
-                "name": "value",
-                "type": "uint256",
-                "indexed": false
-            }
-        ],
-        "anonymous": false,
-        "type": "event"
-    },
-    {
-        "name": "UpdateLiquidityLimit",
-        "inputs": [
-            {
-                "name": "user",
-                "type": "address",
-                "indexed": true
+              "name": "period_finish",
+              "type": "uint256"
             },
             {
-                "name": "original_balance",
-                "type": "uint256",
-                "indexed": false
+              "name": "rate",
+              "type": "uint256"
             },
             {
-                "name": "original_supply",
-                "type": "uint256",
-                "indexed": false
+              "name": "last_update",
+              "type": "uint256"
             },
             {
-                "name": "working_balance",
-                "type": "uint256",
-                "indexed": false
-            },
-            {
-                "name": "working_supply",
-                "type": "uint256",
-                "indexed": false
+              "name": "integral",
+              "type": "uint256"
             }
-        ],
-        "anonymous": false,
-        "type": "event"
+          ]
+        }
+      ]
     },
     {
-        "name": "Transfer",
-        "inputs": [
-            {
-                "name": "_from",
-                "type": "address",
-                "indexed": true
-            },
-            {
-                "name": "_to",
-                "type": "address",
-                "indexed": true
-            },
-            {
-                "name": "_value",
-                "type": "uint256",
-                "indexed": false
-            }
-        ],
-        "anonymous": false,
-        "type": "event"
+      "stateMutability": "view",
+      "type": "function",
+      "name": "rewards_receiver",
+      "inputs": [
+        {
+          "name": "arg0",
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ]
     },
     {
-        "name": "Approval",
-        "inputs": [
-            {
-                "name": "_owner",
-                "type": "address",
-                "indexed": true
-            },
-            {
-                "name": "_spender",
-                "type": "address",
-                "indexed": true
-            },
-            {
-                "name": "_value",
-                "type": "uint256",
-                "indexed": false
-            }
-        ],
-        "anonymous": false,
-        "type": "event"
+      "stateMutability": "view",
+      "type": "function",
+      "name": "reward_integral_for",
+      "inputs": [
+        {
+          "name": "arg0",
+          "type": "address"
+        },
+        {
+          "name": "arg1",
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
     },
     {
-        "stateMutability": "nonpayable",
-        "type": "constructor",
-        "inputs": [],
-        "outputs": []
+      "stateMutability": "view",
+      "type": "function",
+      "name": "working_balances",
+      "inputs": [
+        {
+          "name": "arg0",
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
     },
     {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "deposit",
-        "inputs": [
-            {
-                "name": "_value",
-                "type": "uint256"
-            }
-        ],
-        "outputs": [],
-        "gas": 4221717
+      "stateMutability": "view",
+      "type": "function",
+      "name": "working_supply",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
     },
     {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "deposit",
-        "inputs": [
-            {
-                "name": "_value",
-                "type": "uint256"
-            },
-            {
-                "name": "_addr",
-                "type": "address"
-            }
-        ],
-        "outputs": [],
-        "gas": 4221717
+      "stateMutability": "view",
+      "type": "function",
+      "name": "integrate_inv_supply_of",
+      "inputs": [
+        {
+          "name": "arg0",
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
     },
     {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "deposit",
-        "inputs": [
-            {
-                "name": "_value",
-                "type": "uint256"
-            },
-            {
-                "name": "_addr",
-                "type": "address"
-            },
-            {
-                "name": "_claim_rewards",
-                "type": "bool"
-            }
-        ],
-        "outputs": [],
-        "gas": 4221717
+      "stateMutability": "view",
+      "type": "function",
+      "name": "integrate_checkpoint_of",
+      "inputs": [
+        {
+          "name": "arg0",
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
     },
     {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "withdraw",
-        "inputs": [
-            {
-                "name": "_value",
-                "type": "uint256"
-            }
-        ],
-        "outputs": [],
-        "gas": 4221322
+      "stateMutability": "view",
+      "type": "function",
+      "name": "integrate_fraction",
+      "inputs": [
+        {
+          "name": "arg0",
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
     },
     {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "withdraw",
-        "inputs": [
-            {
-                "name": "_value",
-                "type": "uint256"
-            },
-            {
-                "name": "_claim_rewards",
-                "type": "bool"
-            }
-        ],
-        "outputs": [],
-        "gas": 4221322
+      "stateMutability": "view",
+      "type": "function",
+      "name": "period",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "int128"
+        }
+      ]
     },
     {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "claim_rewards",
-        "inputs": [],
-        "outputs": [],
-        "gas": 1374701
+      "stateMutability": "view",
+      "type": "function",
+      "name": "reward_tokens",
+      "inputs": [
+        {
+          "name": "arg0",
+          "type": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ]
     },
     {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "claim_rewards",
-        "inputs": [
-            {
-                "name": "_addr",
-                "type": "address"
-            }
-        ],
-        "outputs": [],
-        "gas": 1374701
+      "stateMutability": "view",
+      "type": "function",
+      "name": "period_timestamp",
+      "inputs": [
+        {
+          "name": "arg0",
+          "type": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
     },
     {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "claim_rewards",
-        "inputs": [
-            {
-                "name": "_addr",
-                "type": "address"
-            },
-            {
-                "name": "_receiver",
-                "type": "address"
-            }
-        ],
-        "outputs": [],
-        "gas": 1374701
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "transferFrom",
-        "inputs": [
-            {
-                "name": "_from",
-                "type": "address"
-            },
-            {
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "name": "_value",
-                "type": "uint256"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "gas": 8330946
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "transfer",
-        "inputs": [
-            {
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "name": "_value",
-                "type": "uint256"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "gas": 8293026
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "approve",
-        "inputs": [
-            {
-                "name": "_spender",
-                "type": "address"
-            },
-            {
-                "name": "_value",
-                "type": "uint256"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "gas": 39241
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "permit",
-        "inputs": [
-            {
-                "name": "_owner",
-                "type": "address"
-            },
-            {
-                "name": "_spender",
-                "type": "address"
-            },
-            {
-                "name": "_value",
-                "type": "uint256"
-            },
-            {
-                "name": "_deadline",
-                "type": "uint256"
-            },
-            {
-                "name": "_v",
-                "type": "uint8"
-            },
-            {
-                "name": "_r",
-                "type": "bytes32"
-            },
-            {
-                "name": "_s",
-                "type": "bytes32"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "gas": 102311
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "increaseAllowance",
-        "inputs": [
-            {
-                "name": "_spender",
-                "type": "address"
-            },
-            {
-                "name": "_added_value",
-                "type": "uint256"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "gas": 41801
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "decreaseAllowance",
-        "inputs": [
-            {
-                "name": "_spender",
-                "type": "address"
-            },
-            {
-                "name": "_subtracted_value",
-                "type": "uint256"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "gas": 41827
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "user_checkpoint",
-        "inputs": [
-            {
-                "name": "addr",
-                "type": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "gas": 2767499
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "set_rewards_receiver",
-        "inputs": [
-            {
-                "name": "_receiver",
-                "type": "address"
-            }
-        ],
-        "outputs": [],
-        "gas": 35820
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "kick",
-        "inputs": [
-            {
-                "name": "addr",
-                "type": "address"
-            }
-        ],
-        "outputs": [],
-        "gas": 2781198
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "deposit_reward_token",
-        "inputs": [
-            {
-                "name": "_reward_token",
-                "type": "address"
-            },
-            {
-                "name": "_amount",
-                "type": "uint256"
-            }
-        ],
-        "outputs": [],
-        "gas": 1492175
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "add_reward",
-        "inputs": [
-            {
-                "name": "_reward_token",
-                "type": "address"
-            },
-            {
-                "name": "_distributor",
-                "type": "address"
-            }
-        ],
-        "outputs": [],
-        "gas": 115333
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "set_reward_distributor",
-        "inputs": [
-            {
-                "name": "_reward_token",
-                "type": "address"
-            },
-            {
-                "name": "_distributor",
-                "type": "address"
-            }
-        ],
-        "outputs": [],
-        "gas": 43078
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "set_killed",
-        "inputs": [
-            {
-                "name": "_is_killed",
-                "type": "bool"
-            }
-        ],
-        "outputs": [],
-        "gas": 40381
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "claimed_reward",
-        "inputs": [
-            {
-                "name": "_addr",
-                "type": "address"
-            },
-            {
-                "name": "_token",
-                "type": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 3502
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "claimable_reward",
-        "inputs": [
-            {
-                "name": "_user",
-                "type": "address"
-            },
-            {
-                "name": "_reward_token",
-                "type": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 20471
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "claimable_tokens",
-        "inputs": [
-            {
-                "name": "addr",
-                "type": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 2683603
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "integrate_checkpoint",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 5172
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "future_epoch_time",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 3066
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "inflation_rate",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 3120
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "decimals",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 1020
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "version",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "gas": 6677
-    },
-    {
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "initialize",
-        "inputs": [
-            {
-                "name": "_lp_token",
-                "type": "address"
-            }
-        ],
-        "outputs": [],
-        "gas": 412936
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "balanceOf",
-        "inputs": [
-            {
-                "name": "arg0",
-                "type": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 3476
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "totalSupply",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 3240
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "allowance",
-        "inputs": [
-            {
-                "name": "arg0",
-                "type": "address"
-            },
-            {
-                "name": "arg1",
-                "type": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 3802
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "name",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "gas": 13589
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "symbol",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "gas": 13619
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "DOMAIN_SEPARATOR",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "gas": 3360
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "nonces",
-        "inputs": [
-            {
-                "name": "arg0",
-                "type": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 3656
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "factory",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "gas": 3420
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "lp_token",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "gas": 3450
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "is_killed",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "gas": 3480
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "reward_count",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 3510
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "reward_data",
-        "inputs": [
-            {
-                "name": "arg0",
-                "type": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "tuple",
-                "components": [
-                    {
-                        "name": "token",
-                        "type": "address"
-                    },
-                    {
-                        "name": "distributor",
-                        "type": "address"
-                    },
-                    {
-                        "name": "period_finish",
-                        "type": "uint256"
-                    },
-                    {
-                        "name": "rate",
-                        "type": "uint256"
-                    },
-                    {
-                        "name": "last_update",
-                        "type": "uint256"
-                    },
-                    {
-                        "name": "integral",
-                        "type": "uint256"
-                    }
-                ]
-            }
-        ],
-        "gas": 14427
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "rewards_receiver",
-        "inputs": [
-            {
-                "name": "arg0",
-                "type": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "gas": 3836
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "reward_integral_for",
-        "inputs": [
-            {
-                "name": "arg0",
-                "type": "address"
-            },
-            {
-                "name": "arg1",
-                "type": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 4132
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "working_balances",
-        "inputs": [
-            {
-                "name": "arg0",
-                "type": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 3896
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "working_supply",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 3660
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "integrate_inv_supply_of",
-        "inputs": [
-            {
-                "name": "arg0",
-                "type": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 3956
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "integrate_checkpoint_of",
-        "inputs": [
-            {
-                "name": "arg0",
-                "type": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 3986
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "integrate_fraction",
-        "inputs": [
-            {
-                "name": "arg0",
-                "type": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 4016
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "period",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "int128"
-            }
-        ],
-        "gas": 3780
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "reward_tokens",
-        "inputs": [
-            {
-                "name": "arg0",
-                "type": "uint256"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "gas": 3855
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "period_timestamp",
-        "inputs": [
-            {
-                "name": "arg0",
-                "type": "uint256"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 3885
-    },
-    {
-        "stateMutability": "view",
-        "type": "function",
-        "name": "integrate_inv_supply",
-        "inputs": [
-            {
-                "name": "arg0",
-                "type": "uint256"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "gas": 3915
+      "stateMutability": "view",
+      "type": "function",
+      "name": "integrate_inv_supply",
+      "inputs": [
+        {
+          "name": "arg0",
+          "type": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ]
     }
-]
+  ]

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -218,6 +218,10 @@ templates:
       callHandlers:
         - function: deposit_reward_token(address,uint256)
           handler: handleDepositRewardToken
+        - function: killGauge()
+          handler: handleKillGauge
+        - function: unkillGauge()
+          handler: handleUnkillGauge
   - kind: ethereum/contract
     name: RewardsOnlyGauge
     # prettier-ignore
@@ -242,3 +246,24 @@ templates:
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
+  - kind: ethereum/contract
+    name: RootGauge
+    # prettier-ignore
+    network: {{network}}
+    source:
+      abi: ArbitrumRootGauge
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/gauge.ts
+      entities:
+        - RootGauge
+      abis:
+        - name: ArbitrumRootGauge
+          file: ./abis/ArbitrumRootGauge.json
+      callHandlers:
+        - function: killGauge()
+          handler: handleKillGauge
+        - function: unkillGauge()
+          handler: handleUnkillGauge

--- a/schema.graphql
+++ b/schema.graphql
@@ -23,6 +23,7 @@ type LiquidityGauge @entity {
   symbol: String!
   poolAddress: Bytes!
   poolId: Bytes
+  isKilled: Boolean!
   streamer: Bytes # ChildChainLiquidityGauge Only
   factory: GaugeFactory!
   totalSupply: BigDecimal!
@@ -40,6 +41,7 @@ type RootGauge @entity {
   id: ID!
   chain: Chain!
   recipient: Bytes!
+  isKilled: Boolean!
 }
 
 type Gauge @entity {

--- a/scripts/generate-manifests.ts
+++ b/scripts/generate-manifests.ts
@@ -7,14 +7,14 @@ import path = require('path');
 const generateManifests = async (): Promise<void> => {
   const networksFilePath = path.resolve(__dirname, '../networks.yaml');
   const networks: Record<string, Record<string, unknown>> = yaml.load(
-    await fs.readFile(networksFilePath, { encoding: 'utf-8' })
+    await fs.readFile(networksFilePath, { encoding: 'utf-8' }),
   );
 
-  const template = fs.readFileSync('subgraph.template.yaml').toString();
+  const template = fs.readFileSync('manifest.template.yaml').toString();
   Object.entries(networks).forEach(([network, config]) => {
     fs.writeFileSync(
       `subgraph${network === 'mainnet' ? '' : `.${network}`}.yaml`,
-      Handlebars.compile(template)(config)
+      Handlebars.compile(template)(config),
     );
   });
 

--- a/src/gauge.ts
+++ b/src/gauge.ts
@@ -1,13 +1,17 @@
 import { ZERO_ADDRESS } from './utils/constants';
 import { getGaugeShare, getRewardToken } from './utils/gauge';
 import { scaleDown, scaleDownBPT } from './utils/maths';
-import { LiquidityGauge } from './types/schema';
+import { LiquidityGauge, RootGauge } from './types/schema';
 
 import {
   Transfer,
   // eslint-disable-next-line camelcase
   Deposit_reward_tokenCall,
 } from './types/templates/LiquidityGauge/LiquidityGauge';
+import {
+  KillGaugeCall,
+  UnkillGaugeCall,
+} from './types/templates/RootGauge/ArbitrumRootGauge';
 
 // eslint-disable-next-line camelcase
 export function handleDepositRewardToken(call: Deposit_reward_tokenCall): void {
@@ -56,5 +60,19 @@ export function handleTransfer(event: Transfer): void {
     userShareFrom.save();
   }
 
+  gauge.save();
+}
+
+export function handleKillGauge(call: KillGaugeCall): void {
+  // eslint-disable-next-line no-underscore-dangle
+  let gauge = RootGauge.load(call.to.toHexString()) as RootGauge;
+  gauge.isKilled = true;
+  gauge.save();
+}
+
+export function handleUnkillGauge(call: UnkillGaugeCall): void {
+  // eslint-disable-next-line no-underscore-dangle
+  let gauge = RootGauge.load(call.to.toHexString()) as RootGauge;
+  gauge.isKilled = false;
   gauge.save();
 }

--- a/src/gaugeFactory.ts
+++ b/src/gaugeFactory.ts
@@ -5,6 +5,7 @@ import { GaugeFactory, RootGauge } from './types/schema';
 import { getGauge } from './utils/gauge';
 
 import {
+  RootGauge as RootGaugeTemplate,
   LiquidityGauge as LiquidityGaugeTemplate,
   RewardsOnlyGauge as RewardsOnlyGaugeTemplate,
 } from './types/templates';
@@ -66,6 +67,7 @@ export function handleRootGaugeCreated(event: ArbitrumRootGaugeCreated): void {
 
   let gauge = new RootGauge(gaugeAddress.toHexString());
   gauge.recipient = event.params.recipient;
+  gauge.isKilled = false;
 
   if (event.address == ARBITRUM_ROOT_GAUGE_FACTORY) {
     gauge.chain = 'Arbitrum';
@@ -76,4 +78,6 @@ export function handleRootGaugeCreated(event: ArbitrumRootGaugeCreated): void {
   }
 
   gauge.save();
+
+  RootGaugeTemplate.create(gaugeAddress);
 }


### PR DESCRIPTION
Adds `callHandlers` to track the `kill` state from gauges. Changes on `LiquidityGauge` ABI happened because it was outdated. I also took the opportunity to rename the manifest file template to follow the pattern we have in the main Subgraph.