### PR TITLE
add updatedAt to locks

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -10,6 +10,7 @@ type VotingEscrowLock @entity {
   unlockTime: BigInt
   lockedBalance: BigDecimal!
   votingEscrowID: VotingEscrow!
+  updatedAt: Int!
 }
 
 type GaugeFactory @entity {

--- a/src/voting.ts
+++ b/src/voting.ts
@@ -22,6 +22,7 @@ export function handleDeposit(event: Deposit): void {
   votingShare.unlockTime = event.params.locktime;
   let depositAmount = scaleDownBPT(event.params.value);
   votingShare.lockedBalance = votingShare.lockedBalance.plus(depositAmount);
+  votingShare.updatedAt = event.block.timestamp.toI32();
   votingShare.save();
 }
 
@@ -39,6 +40,7 @@ export function handleWithdraw(event: Withdraw): void {
   }
 
   votingShare.lockedBalance = ZERO_BD;
+  votingShare.updatedAt = event.block.timestamp.toI32();
   votingShare.save();
 }
 


### PR DESCRIPTION
Adds `updatedAt` field to `VotingEscrowLock` entity. This will allow Balancer front-end to know the last time a given user updated the veBAL position.