### PR TITLE
comment out callhandlers

### DIFF
--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -348,13 +348,13 @@ templates:
           handler: handleRelativeWeightCapChanged
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
-      callHandlers:
-        - function: deposit_reward_token(address,uint256)
-          handler: handleDepositRewardToken
-        - function: killGauge()
-          handler: handleKillGauge
-        - function: unkillGauge()
-          handler: handleUnkillGauge
+      # callHandlers:
+      #   - function: deposit_reward_token(address,uint256)
+      #     handler: handleDepositRewardToken
+      #   - function: killGauge()
+      #     handler: handleKillGauge
+      #   - function: unkillGauge()
+      #     handler: handleUnkillGauge
   - kind: ethereum/contract
     name: RewardsOnlyGauge
     # prettier-ignore
@@ -398,8 +398,8 @@ templates:
       eventHandlers:
         - event: RelativeWeightCapChanged(uint256)
           handler: handleRootGaugeRelativeWeightCapChanged
-      callHandlers:
-        - function: killGauge()
-          handler: handleRootKillGauge
-        - function: unkillGauge()
-          handler: handleRootUnkillGauge
+      # callHandlers:
+      #   - function: killGauge()
+      #     handler: handleRootKillGauge
+      #   - function: unkillGauge()
+      #     handler: handleRootUnkillGauge


### PR DESCRIPTION
There's a bug in Erigon that's causing issues with the trace-filter call which is used by callHandlers: https://github.com/ledgerwatch/erigon/issues/5306

We're temporarily removing `callHandlers` to avoid the issue.