### PR TITLE
fix l2 reward tokens

### DIFF
--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -439,6 +439,8 @@ templates:
       abis:
         - name: ERC20
           file: ./abis/ERC20.json
+        - name: ChildChainStreamer
+          file: ./abis/ChildChainStreamer.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleChildChainTransfer

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -396,9 +396,9 @@ templates:
       abis:
         - name: ChildChainStreamer
           file: ./abis/ChildChainStreamer.json
-      callHandlers:
-        - function: notify_reward_amount(address)
-          handler: handleNotifyRewardAmount
+      eventHandlers:
+        - event: RewardDurationUpdated(indexed address,uint256)
+          handler: handleRewardDurationUpdated
   - kind: ethereum/contract
     name: RootGauge
     # prettier-ignore
@@ -423,3 +423,22 @@ templates:
           handler: handleRootKillGauge
         - function: unkillGauge()
           handler: handleRootUnkillGauge
+  - kind: ethereum/contract
+    name: ChildChainRewardToken
+    # prettier-ignore
+    network: {{network}}
+    source:
+      abi: ERC20
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/gauge.ts
+      entities:
+        - RewardToken
+      abis:
+        - name: ERC20
+          file: ./abis/ERC20.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleChildChainTransfer

--- a/src/utils/gauge.ts
+++ b/src/utils/gauge.ts
@@ -155,10 +155,10 @@ export function setChildChainGaugeRewardData(gaugeAddress: Address, tokenAddress
 
   const rewardToken = getRewardToken(tokenAddress, gaugeAddress);
   const rateScaled = scaleDownBPT(rewardDataCall.value.rate);
-  const amountScaled = scaleDown(rewardDataCall.value.received, rewardToken.decimals);
+  const receivedScaled = scaleDown(rewardDataCall.value.received, rewardToken.decimals);
 
   rewardToken.periodFinish = rewardDataCall.value.period_finish;
-  rewardToken.totalDeposited = rewardToken.totalDeposited.plus(amountScaled);
+  rewardToken.totalDeposited = receivedScaled;
   rewardToken.rate = rateScaled;
   rewardToken.save();
 }

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -6,6 +6,10 @@ import { WeightedPool } from '../types/GaugeFactory/WeightedPool';
 import { Vault } from '../types/GaugeFactory/Vault';
 import { VAULT_ADDRESS } from './constants';
 
+export function bytesToAddress(address: Bytes): Address {
+  return Address.fromString(address.toHexString());
+}
+
 export function createUserEntity(address: Address): void {
   let addressHex = address.toHex();
   if (User.load(addressHex) == null) {


### PR DESCRIPTION
This PR adds support to L2's rewards tokens based on `eventHandlers` since some chains don't support `callHandlers`. 

Basically, on the `RewardDurationUpdated` event, the reward token is created as a template, and the Subgraph starts tracking it. Then, on each `Transfer` event of those tokens, we check if it was transferred to a `RewardsOnlyGauge` and, if so, we update the data by calling `reward_data()` from the `ChildChainStreamer`.